### PR TITLE
Fix resize regression

### DIFF
--- a/src/clusterize.js
+++ b/src/clusterize.js
@@ -73,7 +73,7 @@ class Clusterize extends EventEmitter {
 
                 this.computeHeight();
 
-                if (prevItemHeight !== this.state.itemHeight) {
+                if (this.state.itemHeight > 0 && prevItemHeight !== this.state.itemHeight) {
                     this.update();
                 }
             }, 100);


### PR DESCRIPTION
Hi.

After upgrading to infinite-tree 1.14.1 (thanks for performance improvements BTW 👍 )
We noticed one interesting bug.

We are fixing bootstrap tabs. Each tab contains one or more trees.
When you switch from one tab to another, bootstrap uses "display: none" to hide one tab and show another.
This means, that invisible tab will have clientHeight = 0
So, when i switch from tab 1 to tab 2 and then resize browser window, rows on tab 1 disappears.
The reason is pretty simple. It cannot calculate clientHeight of the node in the middle.

I see that you in-sourced and partially re-written clustorize.js.
However, i think, that at that point you also introduced one small regression:

https://github.com/NeXTs/Clusterize.js/blob/617159b82cf91662650a5d56ffd0960986e6a7ef/clusterize.js#L110

Clustorize.js was checking for rowHeight not to be 0 before doing refresh on resize.

This PR is intended to return old behaviour. Row heights must be re-calculated only when it makes sense and it's possible :)