### PR TITLE
Fix clusterHeight() to use most current state information

### DIFF
--- a/dist/infinite-tree.js
+++ b/dist/infinite-tree.js
@@ -3295,11 +3295,13 @@ var Clusterize = function (_EventEmitter) {
                 itemHeight += Math.max(marginTop, marginBottom);
             }
 
-            return {
-                blockHeight: this.state.itemHeight * this.options.rowsInBlock,
-                clusterHeight: this.state.blockHeight * this.options.blocksInCluster,
-                itemHeight: itemHeight
-            };
+			var blockHeight = itemHeight * this.options.rowsInBlock;
+
+			return {
+				blockHeight,
+				clusterHeight: blockHeight * this.options.blocksInCluster,
+				itemHeight
+			};
         }
     };
 

--- a/src/clusterize.js
+++ b/src/clusterize.js
@@ -193,9 +193,11 @@ class Clusterize extends EventEmitter {
                 itemHeight += Math.max(marginTop, marginBottom);
             }
 
+            const blockHeight = itemHeight * this.options.rowsInBlock
+
             return {
-                blockHeight: this.state.itemHeight * this.options.rowsInBlock,
-                clusterHeight: this.state.blockHeight * this.options.blocksInCluster,
+                blockHeight,
+                clusterHeight: blockHeight * this.options.blocksInCluster,
                 itemHeight
             };
         }


### PR DESCRIPTION
Currently `computeHeight` uses old `this.state` data to compute the clusterHeight. If the clusterHeight has changed, then this results in requring the coder to call `tree.update` twice.