### PR TITLE
Clean up pedantic console warnings in IE11

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -228,10 +228,12 @@
                         <div class="col-xs-12">
                             <table class="filebrowser-header" width="100%">
                                 <thead>
+                                  <tr>
                                     <th>Name</th>
                                     <th>Size</th>
                                     <th>Type</th>
                                     <th>Modified Date</th>
+                                  </tr>
                                 </thead>
                             </table>
                             <div class="tree" data-id="tree"></div>
@@ -240,7 +242,7 @@
                 </div>
             </section>
         </div>
-    <div>
+    </div>
 </div>
 <script src="common.js"></script>
 <script src="navbar.js"></script>


### PR DESCRIPTION
Trivial changes to the examples.html page that I came across while trying to debug an IE11 problem - IE11 developer console generates some noise:

HTML1503: Unexpected start tag.
examples.html (231,37)
...
HTML1521: Unexpected "</body>" or end of file. All open elements should be closed before the end of the document.
examples.html (248,1)

