### PR TITLE
在update的时候重新计算row

### DIFF
--- a/src/infinite-tree.js
+++ b/src/infinite-tree.js
@@ -1727,6 +1727,13 @@ class InfiniteTree extends events.EventEmitter {
         // Emit a "contentWillUpdate" event
         this.emit('contentWillUpdate');
 
+        // Update rows
+        this.rows.length = this.nodes.length;
+        for (var i = 0; i < this.nodes.length; ++i) {
+            var node = this.nodes[i];
+            this.rows[i] = this.options.rowRenderer(node, this.options);
+        }
+
         if (this.clusterize) {
             // Update list
             const rows = this.rows.filter(row => !!row);


### PR DESCRIPTION
发现在选中节点后，添加删除节点的功能，调用update的时候，DOM tree并不会变，因为ROWS在之前删除前已经定义好，感觉需要在update中重新计算一下row