### PR TITLE
Give user more control on number of rows to be rendered at a time

### DIFF
--- a/src/infinite-tree.js
+++ b/src/infinite-tree.js
@@ -72,6 +72,10 @@ class InfiniteTree extends events.EventEmitter {
         selectable: true,
         shouldSelectNode: null,
 
+        // Allow user to create - how many rows to be rendered at a time.
+        rowsInBlock: 50,
+        blocksInCluster: 4,
+
         // When el is not specified, the tree will run in the stealth mode
         el: null,
 
@@ -376,7 +380,9 @@ class InfiniteTree extends events.EventEmitter {
                 scrollElement: this.scrollElement,
                 contentElement: this.contentElement,
                 emptyText: this.options.noDataText,
-                emptyClass: this.options.noDataClass
+                emptyClass: this.options.noDataClass,
+                rowsInBlock: this.options.rowsInBlock,
+                blocksInCluster: this.options.blocksInCluster,
             });
 
             this.clusterize.on('clusterWillChange', () => {

--- a/src/infinite-tree.js
+++ b/src/infinite-tree.js
@@ -72,7 +72,7 @@ class InfiniteTree extends events.EventEmitter {
         selectable: true,
         shouldSelectNode: null,
 
-        // Allow user to create - how many rows to be rendered at a time.
+        // Allow user to define the number of rows, and blocks to be rendered.
         rowsInBlock: 50,
         blocksInCluster: 4,
 


### PR DESCRIPTION
Allow user to select the number rows to be rendered in a block, and total number blocks to be rendered at a time.

This customisation will allow a user to define these parameters during initialisation based on the height of the tree container.