### PR TITLE
Fix scrollToNode function

### DIFF
--- a/src/infinite-tree.js
+++ b/src/infinite-tree.js
@@ -1492,10 +1492,11 @@ class InfiniteTree extends events.EventEmitter {
         }
 
         // Scroll to a desired position
+        const prefix = 'infinite-tree-';
         let firstChild = this.contentElement.firstChild;
         while (firstChild) {
             const className = firstChild.className || '';
-            if (className.indexOf('clusterize-extra-row') < 0 && (firstChild.offsetHeight > 0)) {
+            if (className.indexOf(prefix + 'extra-row') < 0 && (firstChild.offsetHeight > 0)) {
                 break;
             }
             firstChild = firstChild.nextSibling;


### PR DESCRIPTION
At some point the prefix for the extra row class must have been changed from "clusterize" to "infinite-tree". This stops the scrollToNode function from working correctly when the tree wasn't scrolled all the way to the top because it specifies "clusterize-extra-row".
Just changing "clusterize-extra-row" to "infinite-tree-extra-row" fixes this.