### PR TITLE
Fixed the missing dependency of events package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "escape-html": "^1.0.3",
     "flattree": "^0.11.1",
     "html5-tag": "^0.3.0",
-    "is-dom": "^1.1.0"
+    "is-dom": "^1.1.0",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@babel/cli": "~7.6.0",


### PR DESCRIPTION
Hello, I have a problem with the missing dependency of the `events` package，`events` should be the dependency in this project. https://github.com/cheton/infinite-tree/blob/master/src/clusterize.js#L1
@cheton 